### PR TITLE
Fix deprecation

### DIFF
--- a/lib/ssh-executor.js
+++ b/lib/ssh-executor.js
@@ -7,7 +7,7 @@ module.exports = CoreObject.extend({
   client: null,
 
   init: function() {
-    this._super.init.apply(this, arguments);
+    this._super(...arguments);
 
     if (!this.client) {
       this.client = new ssh2.Client();


### PR DESCRIPTION
```
DEPRECATION: Calling this._super.init is deprecated. Please use this._super(args).
```